### PR TITLE
Add README and implementation for problem 1455: Check If a Word Occur…

### DIFF
--- a/leetcode/easy/problem1455/README.md
+++ b/leetcode/easy/problem1455/README.md
@@ -1,0 +1,30 @@
+# 1455. Check If a Word Occurs As a Prefix of Any Word in a Sentence
+
+https://leetcode.com/problems/check-if-a-word-occurs-as-a-prefix-of-any-word-in-a-sentence/
+
+Given a `sentence` that consists of some words separated by a **single space**, and a `searchWord`, check if `searchWord` is a prefix of any word in `sentence`.
+
+Return _the index of the word in_ `sentence` _(**1-indexed**) where_ `searchWord` _is a prefix of this word_. If `searchWord` is a prefix of more than one word, return the index of the first word **(minimum index)**. If there is no such word return `-1`.
+
+A **prefix** of a string `s` is any leading contiguous substring of `s`.
+
+**Example 1:**\
+**Input:** `sentence = "i love eating burger", searchWord = "burg"`\
+**Output:** `4`\
+**Explanation:** `"burg" is prefix of "burger" which is the 4th word in the sentence.`
+
+**Example 2:**\
+**Input:** `sentence = "this problem is an easy problem", searchWord = "pro"`\
+**Output:** `2`\
+**Explanation:** `"pro" is prefix of "problem" which is the 2nd and the 6th word in the sentence, but we return 2 as it's the minimal index.`
+
+**Example 3:**\
+**Input:** `sentence = "i am tired", searchWord = "you"`\
+**Output:** `-1`\
+**Explanation:** `"you" is not a prefix of any word in the sentence.`
+
+**Constraints:**
+-   `1 <= sentence.length <= 100`
+-   `1 <= searchWord.length <= 10`
+-   `sentence` consists of lowercase English letters and spaces.
+-   `searchWord` consists of lowercase English letters.

--- a/leetcode/easy/problem1455/isPrefixOfWord.go
+++ b/leetcode/easy/problem1455/isPrefixOfWord.go
@@ -1,0 +1,15 @@
+package problem1455
+
+import "strings"
+
+func isPrefixOfWord(sentence string, searchWord string) int {
+	words := strings.Split(sentence, " ")
+
+	for i, w := range words {
+		if strings.HasPrefix(w, searchWord) {
+			return i + 1
+		}
+	}
+
+	return -1
+}

--- a/leetcode/easy/problem1455/isPrefixOfWord_test.go
+++ b/leetcode/easy/problem1455/isPrefixOfWord_test.go
@@ -1,0 +1,54 @@
+package problem1455
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPrefixOfWord(t *testing.T) {
+	tests := []struct {
+		name       string
+		sentence   string
+		searchWord string
+		expected   int
+	}{
+		{
+			name:       "Example 1",
+			sentence:   "i love eating burger",
+			searchWord: "burg",
+			expected:   4,
+		},
+		{
+			name:       "Example 2",
+			sentence:   "this problem is an easy problem",
+			searchWord: "pro",
+			expected:   2,
+		},
+		{
+			name:       "Example 3",
+			sentence:   "i am tired",
+			searchWord: "you",
+			expected:   -1,
+		},
+		{
+			name:       "No match",
+			sentence:   "hello world",
+			searchWord: "test",
+			expected:   -1,
+		},
+		{
+			name:       "Match first word",
+			sentence:   "test the function",
+			searchWord: "test",
+			expected:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isPrefixOfWord(tt.sentence, tt.searchWord)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
…s As a Prefix of Any Word in a Sentence

- Create README.md with problem description, examples, and constraints.
- Implement `isPrefixOfWord` function in Go to check if `searchWord` is a prefix of any word in `sentence`.
- Add unit tests for various scenarios including edge cases.